### PR TITLE
Improve Advanced Reboot button to match with System UI

### DIFF
--- a/app/src/main/java/it/dhd/oxygencustomizer/xposed/hooks/systemui/AdvancedReboot.java
+++ b/app/src/main/java/it/dhd/oxygencustomizer/xposed/hooks/systemui/AdvancedReboot.java
@@ -17,6 +17,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -188,10 +189,12 @@ public class AdvancedReboot extends XposedMods {
         buttonPaint.setColor(mContext.getColor(mContext.getResources().getIdentifier("oplus_road_color", "color", listenPackage)));
         buttonPaint.setStyle(Paint.Style.FILL);
 
+        int density = Resources.getSystem().getConfiguration().densityDpi;
+
         textPaint = new Paint();
-        textPaint.setColor(Color.WHITE);
-        textPaint.setTextSize(50);
+        textPaint.setColor(Color.GRAY);
         textPaint.setTextAlign(Paint.Align.CENTER);
+        textPaint.setTextSize((float) density / 13);
 
         int viewWidth = (int) callMethod(param, "getWidth");
 
@@ -204,15 +207,18 @@ public class AdvancedReboot extends XposedMods {
         canvas.drawCircle(centerX, centerY, radius, buttonPaint);
 
         if (mAdvancedRebootDrawable != null) {
-            int iconWidth = mAdvancedRebootDrawable.getIntrinsicWidth();
-            int iconHeight = mAdvancedRebootDrawable.getIntrinsicHeight();
-            Rect iconBounds = new Rect(centerX - iconWidth / 2, centerY - iconHeight / 2, centerX + iconWidth / 2, centerY + iconHeight / 2);
+
+            Rect iconBounds = new Rect(
+                    centerX - radius / 2,
+                    centerY - radius / 2,
+                    centerX + radius / 2,
+                    centerY + radius / 2);
             mAdvancedRebootDrawable.setBounds(iconBounds);
             mAdvancedRebootDrawable.draw(canvas);
         }
 
         float textX = (float) viewWidth / 2;
-        float textY = centerY + radius + dp2px(mContext, 15);
+        float textY = centerY + radius + dp2px(mContext, 20);
         String buttonText = modRes.getString(R.string.advanced_reboot_title);
         canvas.drawText(buttonText, textX, textY, textPaint);
     }


### PR DESCRIPTION
- Adjust text size based on system dp
- Change text color to gray
- Adjust icon size to always be 50% of the button
- Increase button to text margin

This will enable adequate look for the button and text for all screen sizes, and for users that use custom display density.
Screenshots of the result in different (320 -> 800) dp settings,  set via developer options:

<img src="https://github.com/user-attachments/assets/371b239d-2b69-4819-ab9c-b04360b01cdf" width="200" />
<img src="https://github.com/user-attachments/assets/6720bfe0-3e33-401a-8f1f-9a5bf3450b99" width="200" />
<img src="https://github.com/user-attachments/assets/1967287b-cd80-4318-8566-846a1b0a3866" width="200" />
<img src="https://github.com/user-attachments/assets/720805b3-0e74-4972-9a4d-62aaf967ce2d" width="200" />
<img src="https://github.com/user-attachments/assets/a693c90e-111f-4d06-ad51-03de18027101" width="200" />
